### PR TITLE
ci: add check-changelog job, scope publish.yml permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,5 @@
 name: Plugins - CD
 run-name: Deploy ${{ inputs.branch }} to ${{ inputs.environment }} by @${{ github.actor }}
-permissions:
-  attestations: write
-  contents: write
-  id-token: write
-  pull-requests: read
 
 on:
   workflow_dispatch:
@@ -25,10 +20,47 @@ on:
         default: false
         type: boolean
 
+permissions: {}
+
 jobs:
+  check-changelog:
+    name: Check changelog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Verify CHANGELOG.md has no [Unreleased] section
+        run: |
+          UNRELEASED_LINE=$(grep -n "^## \[Unreleased\]" CHANGELOG.md | head -1 | cut -d: -f1)
+          RELEASE_LINE=$(grep -n "^## \[[0-9]" CHANGELOG.md | head -1 | cut -d: -f1)
+
+          # No [Unreleased] section — nothing to check
+          if [ -z "$UNRELEASED_LINE" ]; then
+            exit 0
+          fi
+
+          # [Unreleased] is below the latest release — fine
+          if [ -n "$RELEASE_LINE" ] && [ "$UNRELEASED_LINE" -gt "$RELEASE_LINE" ]; then
+            exit 0
+          fi
+
+          VERSION=$(jq -r '.version' package.json)
+          echo "Error: CHANGELOG.md contains an [Unreleased] section."
+          echo "A released version is required and must match package.json (${VERSION})."
+          exit 1
+
   cd:
     name: CD
+    needs: check-changelog
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+      pull-requests: read
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed changelog entry formatting for versions 6.1.0 and 6.1.1.
 - Bumped version to 6.1.2.
+- Migrated publish workflow from top-level permissions to job-scoped permissions with pre-flight changelog validation.
 
 ## [6.1.1] - 2026-04-27
 


### PR DESCRIPTION
### CI/CD

- `publish.yml`: Add `check-changelog` pre-flight validation job before `cd` — verifies the changelog is already stamped before proceeding.
  Move top-level workflow permissions to job-scoped permissions (`permissions: {}` at root).

## Test plan

- [ ] Trigger publish on a branch with a stamped `CHANGELOG.md` — workflow passes
- [ ] Trigger publish on a branch with an `[Unreleased]` section still present — workflow fails with a clear error
- [ ] Confirm the `cd` job runs after the changelog check passes